### PR TITLE
Add another 10 minutes to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 script:
   - npm run-script pretest
-  - npm run-script coverage
+  - travis_wait 20 npm run-script coverage
 after_script:
   - npm install istanbul-coveralls
   - node node_modules/.bin/istanbul-coveralls


### PR DESCRIPTION
Travis seems to take about 12-15 minutes to build without a cache.
If we give ourselves about a 30% increase in time,
we ought to be alright.
Can always up the number later if not.