### PR TITLE
Remove line ending tests on Windows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,6 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
 indent_style = space
 indent_size = 2
 insert_final_newline = true

--- a/package.json
+++ b/package.json
@@ -60,6 +60,10 @@
     "tape": "^4.7.0"
   },
   "eslintConfig": {
-    "extends": "@shinnn/node"
+    "extends": "@shinnn/node",
+    "rules": {
+      "linebreak-style": "off",
+      "node/shebang": "off"
+    }
   }
 }


### PR DESCRIPTION
Unfortunately, the `.gitattributes` file demands that, on Windows, source files are checked out with CRLF line endings, but the `.editorconfig` (which I don't actually use) and the eslint configuration demand that the source files have LF line endings. The latter breaks the test script on Windows. This commit removes the `.editorconfig` line ending setting and disables the two eslint rules that require LF line endings.

~~An alternative to this fix would just be setting `* text=lf` in `.gitattributes`. I, personally, find this the less appealing approach because git on Windows defaults to CRLF with normalization anyway, and it would require that every contributor's editor insert LF line endings (not *particularly* onerous) or endure git warnings about line ending normalization and possible inconsistencies in their staging area.~~ EDIT: I'm totally mistaken. That just forces git to normalize line endings for all files, even if it suspects them of being binary.

One caveat is the `node/shebang` rule requires LF line endings no matter what, even though shebangs work fine on Windows even with CRLF line endings. So, it's disabled, and now there is no check for correct shebang lines. `bin/psc-package.js` does have one, so don't change it, I guess? It seems like a worthwhile trade off to me at least.

Thanks!