### PR TITLE
Fix package on Windows

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -21,7 +21,7 @@ const removeUnnecessaryFiles = cb => {
   rimraf('*', {
     glob: {
       cwd: bin.dest(),
-      ignore: ['psc-package'],
+      ignore: [bin.use()],
       absolute: true
     }
   }, cb);


### PR DESCRIPTION
Fixes issue #1. On Windows, the behavior was to download or build the `psc-package` executable and then immediately delete it.